### PR TITLE
Entfernen der Funkabhängigkeit, Rundung auf eine Dezimale

### DIFF
--- a/SCD40.ts
+++ b/SCD40.ts
@@ -50,7 +50,9 @@ namespace SCD40 {
         let adc_t = values[1];
         let adc_rh = values[2];
         temperature =  -45 + (175 * adc_t / (1 << 16));
+        temperature = (Math.round(temperature * 10) / 10)
         relative_humidity = 100 * adc_rh / (1 << 16);
+        relative_humidity = (Math.round(relative_humidity * 10) / 10)
     }
 
     /**

--- a/main.blocks
+++ b/main.blocks
@@ -1,1 +1,1 @@
-<xml xmlns="https://developers.google.com/blockly/xml"/>
+<xml xmlns="https://developers.google.com/blockly/xml"><variables><variable id="G?!M0?L#$xI@Q|)x,+lu">temperatur</variable></variables></xml>

--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "co2-sensor-scd40",
-    "version": "0.1.2",
+    "version": "0.2.0",
     "description": "Calliope mini CO2-Sensor",
     "dependencies": {
         "core": "*"

--- a/pxt.json
+++ b/pxt.json
@@ -3,8 +3,7 @@
     "version": "0.1.2",
     "description": "Calliope mini CO2-Sensor",
     "dependencies": {
-        "core": "*",
-        "radio": "*"
+        "core": "*"
     },
     "files": [
         "README.md",
@@ -18,6 +17,10 @@
         "test.ts"
     ],
     "public": true,
+    "targetVersions": {
+        "target": "4.0.29",
+        "targetId": "calliopemini"
+    },
     "supportedTargets": [
         "calliopemini"
     ],


### PR DESCRIPTION
Damit dier Schüler:innen nicht mühevoll runden müssen wurden Temperatur und Feuchtigkeit auf eine Stelle nach dem Komma gerundet. Um Probleme mit Bluetooth zu vermeiden die Funkabhängigkeit entfernt.